### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-demo
+  annotations:
+    github.com/project-slug: stephennewman-lab49/backstage-demo
+spec:
+  type: other
+  lifecycle: unknown
+  owner: team-a


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Lab49 Developer Portal software catalog](https://lab49-ecs-alb-149614342.ap-southeast-2.elb.amazonaws.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).